### PR TITLE
fix: map markers now properly update if no games were found

### DIFF
--- a/client/components/map/Map.js
+++ b/client/components/map/Map.js
@@ -541,7 +541,7 @@ export default function Map () {
   }
   
   useEffect(() => {
-    if (gamesArr.length > 0) { 
+    if (gamesArr.length >= 0) { 
         updateMarkers();
     }
 }, [gamesArr,activeFilter]);


### PR DESCRIPTION
## Overview

**Issue Type**

[ x ] Bug
[ ] Feature
[ ] Tech Debt

**Description**
Just a quick fix for an bug I found while working with the front end.

**Ticket/Card Name** - N/A

**Trello link - ([Trello](https://trello.com/b/LqgdgjQY/iteration-project))**
	
**Steps to Reproduce Bug**

1. Sign in as any* user
2. Check that icons for games are shown on the map
3. Reduce your search radius to 0 miles, and hit the Search Radius button
4. All of the previously shown icons should still be there

**Expected behavior**
With the fix, the map should properly update to show only the valid icons (being zero in this case).
