### PR TITLE
(bug) Address will now account for and catch Geolocation API when use…

### DIFF
--- a/client/components/map/Map.js
+++ b/client/components/map/Map.js
@@ -439,12 +439,32 @@ export default function Map () {
     
   }
   const [manualLoc, manuallySetLoc] = useState({ lat: 37.7749, lng: -122.4194 });
+  const loader = new Loader({
+    apiKey: process.env.GMAPS_API_KEY,
+    version: "weekly",
+  });
+  const addressRef = useRef();
+
   const getCurrentLocation = async () => {
     // const defaultLocation = { lat: 37.7749, lng: -122.4194 };
     return new Promise((resolve) => {
+      let geocoder;
       if (navigator.geolocation) {
+        loader.importLibrary('geocoding')
+          .then(async () => {
+            geocoder = await new google.maps.Geocoder();
+          })
         navigator.geolocation.getCurrentPosition(
           (location) => {
+            geocoder.geocode({'latLng': {
+              lat: location.coords.latitude,
+              lng: location.coords.longitude,
+            }})
+              .then(async (response) => {
+                console.log('geocoded response: ', response);
+                addressRef.current = await response.results[0].formatted_address;
+                console.log('new addressRef: ', addressRef.current);
+              });
             resolve({
               lat: location.coords.latitude,
               lng: location.coords.longitude,
@@ -452,6 +472,7 @@ export default function Map () {
           },
           (error) => {
             console.error('Error retrieving location:', error);
+            addressRef.current = '10 Van Ness Ave, San Francisco, CA 94103';
             resolve(manualLoc);
           }
         );
@@ -531,10 +552,6 @@ export default function Map () {
 
 
   useEffect (() => {
-    const loader = new Loader({
-      apiKey: process.env.GMAPS_API_KEY,
-      version: "weekly",
-    });
     loader.importLibrary('places').then( async ()=>{
       const location = await getCurrentLocation()
       initializeMap(location)
@@ -577,16 +594,11 @@ export default function Map () {
   }, [gamesArr, activeFilter]);
 
   const autocompleteInputRef = useRef();
-  const addressRef = useRef('10 Van Ness Ave, San Francisco, CA 94103');
   const latRef = useRef();
   const lngRef = useRef();
   let autocomplete;
 
   useEffect(() => {
-    const loader = new Loader({
-      apiKey: process.env.GMAPS_API_KEY,
-      version: "weekly"
-    });
     loader.importLibrary('places')
       .then(() => {
         autocomplete = new google.maps.places.Autocomplete(

--- a/client/components/map/Map.js
+++ b/client/components/map/Map.js
@@ -438,7 +438,7 @@ export default function Map () {
     }
     
   }
-  const [manualLoc, manuallySetLoc] = useState({ lat: 37.7749, lng: -122.4194 });
+  const [manualLoc, manuallySetLoc] = useState();
   const loader = new Loader({
     apiKey: process.env.GMAPS_API_KEY,
     version: "weekly",
@@ -449,7 +449,7 @@ export default function Map () {
     // const defaultLocation = { lat: 37.7749, lng: -122.4194 };
     return new Promise((resolve) => {
       let geocoder;
-      if (navigator.geolocation) {
+      if (!manualLoc) {
         loader.importLibrary('geocoding')
           .then(async () => {
             geocoder = await new google.maps.Geocoder();
@@ -473,6 +473,7 @@ export default function Map () {
           (error) => {
             console.error('Error retrieving location:', error);
             addressRef.current = '10 Van Ness Ave, San Francisco, CA 94103';
+            manuallySetLoc({ lat: 37.7749, lng: -122.4194 });
             resolve(manualLoc);
           }
         );


### PR DESCRIPTION
## Overview

**Issue Type**

-[x] Bug
-[ ] Feature
-[ ] Tech Debt

**Description**
Fixed bug where address will default to default location (10 Van Ness Ave, SF); will now check Geolocation API and geocode the returned lat/lng into a formatted address using Google Map's Geocode library

**Ticket/Card Name**

**Trello link - (https://trello.com/c/F4taiO6o)**
	
**Steps to Reproduce Bug**

1. Share location in browser
2. Sign in
3. Confirm incorrect address